### PR TITLE
Allow CLI usage of the package

### DIFF
--- a/pdfalyzer/__main__.py
+++ b/pdfalyzer/__main__.py
@@ -1,0 +1,3 @@
+from pdfalyzer import pdfalyze
+
+pdfalyze()


### PR DESCRIPTION
In some Python environments the script path is not configured properly. People struggle to run code like that.

One pattern that works very reliably is

    python -m name_of_the_package

This PR makes the following work:

    python -m pdfalyzer

See https://docs.python.org/3/library/__main__.html#main-py-in-python-packages