### PR TITLE
Update install_t1utils.sh

### DIFF
--- a/scripts/install_t1utils.sh
+++ b/scripts/install_t1utils.sh
@@ -1,47 +1,52 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
 # Installs the T1Utils suite for working with Adobe Type1 fonts.
 # Requires autoconf and automake on macOS.
 
-if cat /etc/*release | grep ^NAME | egrep 'CentOS|Red|Fedora'; then
-    echo "Installing t1utils with yum..."
+if cat /etc/*release | grep ^NAME | grep -E 'CentOS|Red|Fedora'; then
+    printf "Installing t1utils with yum...\n"
     sudo yum install -y t1utils
     exit 0
-elif cat /etc/*release | grep ^NAME | egrep 'Ubuntu|Debian|Mint|Knoppix'; then
-    echo "Installing t1utils with apt-get..."
+elif cat /etc/*release | grep ^NAME | grep -E 'Ubuntu|Debian|Mint|Knoppix'; then
+    printf "Installing t1utils with apt-get...\n"
     sudo apt-get install -y t1utils
     exit 0
-elif ! echo `uname -a` | grep Darwin 2>&1 >/dev/null; then
-    echo "OS NOT DETECTED, couldn't install t1utils"
-    exit 1;
+elif ! "$(uname -a)" | grep Darwin >/dev/null 2>&1; then
+    printf "OS NOT DETECTED, couldn't install t1utils\n"
+    exit 1
 fi
 
-echo "macOS detected, building t1utils from source..."
-
+printf "macOS detected, building t1utils from source...\n"
 
 for required_build_tool in automake autoconf make; do
-    if ! which $required_build_tool >/dev/null; then
-        echo "Missing $required_build_tool. You may need to run something like 'brew install $required_build_tool'."
+    if ! command -v "${required_build_tool}" >/dev/null; then
+        printf "Missing %s. You may need to run something like 'brew install %s'.\n" "${required_build_tool}" "${required_build_tool}"
     fi
 done
 
-SCRIPT_PATH=$(dirname -- "$(readlink -f -- "$0";)";)
-source "$SCRIPT_PATH/lib/project_paths.sh"
-TMP_DIR="$PDFALYZER_PROJECT_PATH/tmp"
+SCRIPT_PATH="$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")"
+# shellcheck source=./lib/project_paths.sh
+source "${SCRIPT_PATH}/lib/project_paths.sh"
+TMP_DIR="${PDFALYZER_PROJECT_PATH}/tmp"
 
-mkdir -p "$TMP_DIR"
-pushd "$TMP_DIR" >/dev/null
+mkdir -p "${TMP_DIR}"
+pushd "${TMP_DIR}" >/dev/null || exit 1
 git clone https://github.com/kohler/t1utils.git
 
-cd t1utils
+cd t1utils || exit 1
 command autoreconf -i
 ./configure
 
-echo "Successfully configured, building with 'make'..."
+printf "Successfully configured, building with 'make'...\n"
 make
 
-echo "About to run 'make install' as sudo which will place binaries in /usr/local/bin. You will be asked for your password."
-echo "For a different install location you'll need to manually intervene here."
+printf "About to run 'make install' as sudo which will place binaries in /usr/local/bin. You will be asked for your password.\n"
+printf "For a different install location you'll need to manually intervene here.\n"
 sudo mkdir -p /usr/local/bin
 sudo make install
 
-popd >/dev/null
+popd >/dev/null || exit 1


### PR DESCRIPTION
Line 5:
if cat /etc/*release | grep ^NAME | egrep 'CentOS|Red|Fedora'; then
                                    ^-- SC2196 (info): egrep is non-standard and deprecated. Use grep -E instead.
 
Line 9:
elif cat /etc/*release | grep ^NAME | egrep 'Ubuntu|Debian|Mint|Knoppix'; then
                                      ^-- SC2196 (info): egrep is non-standard and deprecated. Use grep -E instead.
 
Line 13:
elif ! echo `uname -a` | grep Darwin 2>&1 >/dev/null; then
            ^-- SC2046 (warning): Quote this to prevent word splitting.
            ^-- SC2005 (style): Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
            ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                                     ^-- SC2069 (warning): To redirect stdout+stderr, 2>&1 must be last (or use '{ cmd > file; } 2>&1' to clarify).

Did you mean: (apply this, apply all SC2006)
elif ! echo $(uname -a) | grep Darwin 2>&1 >/dev/null; then
 
Line 28:
source "$SCRIPT_PATH/lib/project_paths.sh"
       ^-- SC1091 (info): Not following: ./lib/project_paths.sh was not specified as input (see shellcheck -x).